### PR TITLE
Added isCustomAction boolean to execute method for passing customActon 

### DIFF
--- a/android/src/main/kotlin/com/google/flutter/recaptcha/RecaptchaEnterprisePlugin.kt
+++ b/android/src/main/kotlin/com/google/flutter/recaptcha/RecaptchaEnterprisePlugin.kt
@@ -44,10 +44,10 @@ class RecaptchaEnterprisePlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
     channel.setMethodCallHandler(this)
   }
 
-  fun mapAction(actionStr: String): RecaptchaAction {
+  fun mapAction(actionStr: String, isCustomAction: Boolean): RecaptchaAction {
     return when {
-      actionStr.equals("login", ignoreCase = true) -> RecaptchaAction.LOGIN
-      actionStr.equals("signup", ignoreCase = true) -> RecaptchaAction.SIGNUP
+      actionStr.equals("login", ignoreCase = true) && !isCustomAction -> RecaptchaAction.LOGIN
+      actionStr.equals("signup", ignoreCase = true) && !isCustomAction -> RecaptchaAction.SIGNUP
       else -> RecaptchaAction.custom(actionStr)
     }
   }
@@ -82,12 +82,19 @@ class RecaptchaEnterprisePlugin : FlutterPlugin, MethodCallHandler, ActivityAwar
     }
 
     val actionStr = call.argument<String>("action")
+    val isCustomAction = call.argument<Boolean>("isCustomAction")
+
     if (actionStr == null) {
       result.error("FL_EXECUTE_FAILED", "Missing action", null)
       return
     }
 
-    val action = mapAction(actionStr)
+    if (isCustomAction == null) {
+      result.error("FL_EXECUTE_FAILED", "Missing isCustomAction", null)
+      return
+    }
+
+    val action = mapAction(actionStr, isCustomAction)
     val timeout = call.argument<Long>("timeout")
     GlobalScope.launch {
       recaptchaClient

--- a/ios/Classes/SwiftRecaptchaEnterprisePlugin.swift
+++ b/ios/Classes/SwiftRecaptchaEnterprisePlugin.swift
@@ -26,10 +26,11 @@ public class SwiftRecaptchaEnterprisePlugin: NSObject, FlutterPlugin {
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
-  private func mapAction(_ actionStr: String) -> RecaptchaAction {
-    if actionStr.caseInsensitiveCompare("login") == .orderedSame {
+  private func mapAction(_ actionStr: String, isCustomAction: Bool) -> RecaptchaAction {
+
+    if actionStr.caseInsensitiveCompare("login") == .orderedSame && !isCustomAction {
       return RecaptchaAction(action: .login)
-    } else if actionStr.caseInsensitiveCompare("signup") == .orderedSame {
+    } else if actionStr.caseInsensitiveCompare("signup") == .orderedSame && !isCustomAction {
       return RecaptchaAction(action: .signup)
     } else {
       return RecaptchaAction(customAction: actionStr)
@@ -77,9 +78,10 @@ public class SwiftRecaptchaEnterprisePlugin: NSObject, FlutterPlugin {
     }
 
     if let args = call.arguments as? [String: Any],
-      let actionStr = args["action"] as? String
+       let actionStr = args["action"] as? String,
+       let isCustomAction = args["isCustomAction"] as? Bool
     {
-      let action = mapAction(actionStr)
+      let action = mapAction(actionStr, isCustomAction: isCustomAction)
       client.execute(action) { (token, error) -> Void in
         if let token = token {
           result(token.recaptchaToken)

--- a/lib/recaptcha_enterprise.dart
+++ b/lib/recaptcha_enterprise.dart
@@ -20,8 +20,8 @@ class RecaptchaEnterprise {
         .initClient(siteKey, timeout: timeout);
   }
 
-  static Future<String> execute(String action, {double? timeout}) {
+  static Future<String> execute(String action, {bool isCustomAction = false, double? timeout}) {
     return RecaptchaEnterprisePlatform.instance
-        .execute(action, timeout: timeout);
+        .execute(action, timeout: timeout, isCustomAction: isCustomAction);
   }
 }

--- a/lib/recaptcha_enterprise_method_channel.dart
+++ b/lib/recaptcha_enterprise_method_channel.dart
@@ -35,9 +35,10 @@ class MethodChannelRecaptchaEnterprise extends RecaptchaEnterprisePlatform {
   }
 
   @override
-  Future<String> execute(String action, {double? timeout}) async {
+  Future<String> execute(String action, {bool isCustomAction = false, double? timeout}) async {
     Map<String, dynamic> opts = {
       'action': action,
+      'isCustomAction': isCustomAction
     };
 
     if (timeout != null) {

--- a/lib/recaptcha_enterprise_platform_interface.dart
+++ b/lib/recaptcha_enterprise_platform_interface.dart
@@ -42,7 +42,7 @@ abstract class RecaptchaEnterprisePlatform extends PlatformInterface {
     throw UnimplementedError('initClient() has not been implemented.');
   }
 
-  Future<String> execute(String action, {double? timeout}) {
+  Future<String> execute(String action, {bool isCustomAction = false, double? timeout}) {
     throw UnimplementedError('execute() has not been implemented.');
   }
 }


### PR DESCRIPTION
Hi,

currently it isn't possible to pass a customAction "Login" to the SDK, because this action parsed as default action.
We defined a customAction also called "Login", so it needs to be passed to the enterprise SDK as customAction.
To enable this scenario, I added isCustomAction boolean to execute method for passing customActon with similar RecaptchaAction like "login". 

This is a quick fix, if you consider a cleaner solution, you could introduce a RecaptchaAction Data class also on the flutter side.

Greets, Alex

