### PR TITLE
fix: update compileSdk to 35 for AGP 8.x compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Description:
This PR updates the Android configuration for recaptcha_enterprise_flutter to align with modern Android Gradle Plugin (AGP) requirements:
	•	Raised compileSdk from 31 → 35 (minimum required is 34+ by recent AndroidX libraries).

These changes resolve build failures such as:

`Execution failed for task ':recaptcha_enterprise_flutter:checkDebugAarMetadata'.
> Dependency 'androidx.*' requires compileSdk 34 or later...`

With this patch, the plugin builds successfully with AGP 8.13.0 and Flutter stable, and allows generating release APK/AAB without manual overrides.